### PR TITLE
Fix inaccuracy regarding drop of guard during unwinding

### DIFF
--- a/content/posts/understanding-async-await-3.md
+++ b/content/posts/understanding-async-await-3.md
@@ -178,17 +178,13 @@ And we can't accidentally forget to unlock the mutex either.
 
 Once the guard is dropped, the mutex gets unlocked.
 
-And the guard always gets dropped.
-
 Except...
 
 (there is always an except...)
 
 If the thread holding the mutex guard panics.
 
-Then the guard doesn't get dropped.
-
-In Rust, this causes the Mutex to become poisoned.
+Then, when the guard is being dropped (since panics don't prevent drops), the Mutex, rather than unlocked, is _poisoned_.
 
 (you might have seen that mentioned in the code above)
 


### PR DESCRIPTION
Hey, thanks for the post! 🙏 

I've nonetheless wanted to chime in and suggest rewording a tiny bit the section around unwinding and lock poisoning 🙂

Indeed, a panic (or rather, the (stack) unwinding caused by one), does not prevent drop glue from running (in fact, the very reason the unwinding mechanism exists is precisely to be running drop glue!). On the other hand, you are right to point out the `Drop impl` of `MutexGuard` is indeed special insofar it does look at whether it is happening in an unwinding context, in which case it decides to unlock the mutex, but only after having left a "note"/flag in there for the record. Since the `.lock()` operation refuses to silently succeed when that flag has been set, the whole thing is called "poisoning".

I have also removed the "destructors always run" sentence, since code could incorrectly rely on this: memory cycles, or calling the `mem::forget` shorthand explicitly, do prevent destructors from running.

If you wanted to keep a sentence along these lines, then I would suggest to say something along the lines of:
> neither panicking nor `?` (nor other control flow interruptions such as `return`, `break`, and `continue`) prevents destructors from running [making it a very robust mechanism to avoid forgetting to release the mutex]
